### PR TITLE
Add in-browser container execution support

### DIFF
--- a/frontend/public/client/lib.js
+++ b/frontend/public/client/lib.js
@@ -125,6 +125,15 @@ export function KomodoClient(url, options) {
             }
         }
     };
+
+    const executeInBrowser = async (containerId, command) => {
+        const ws = new WebSocket(url.replace("http", "wss") + `/ws/exec/${containerId}`);
+        ws.addEventListener("open", () => {
+            ws.send(JSON.stringify({ type: "exec", params: { command } }));
+        });
+        return ws;
+    };
+
     return {
         /**
          * Call the `/auth` api.
@@ -195,5 +204,16 @@ export function KomodoClient(url, options) {
          * Note. Awaiting this method will never finish.
          */
         subscribe_to_update_websocket,
+        /**
+         * Execute a command in a container in the browser.
+         *
+         * ```
+         * const ws = await komodo.executeInBrowser(containerId, command);
+         * ws.addEventListener("message", (event) => {
+         *   console.log(event.data);
+         * });
+         * ```
+         */
+        executeInBrowser,
     };
 }

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -526,3 +526,29 @@ export const useFilterByUpdateAvailable: () => [boolean, () => void] = () => {
   const [filter, set] = useAtom<boolean>(filter_by_update_available);
   return [filter, () => set(!filter)];
 };
+
+export const useContainerExec = (server: string, container: string) => {
+  const [exec, setExec] = useState<WebSocket | null>(null);
+  const [isPending, setIsPending] = useState(true);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    const ws = komodo_client().executeInBrowser(server, container);
+    ws.onopen = () => {
+      setExec(ws);
+      setIsPending(false);
+    };
+    ws.onerror = () => {
+      setIsError(true);
+      setIsPending(false);
+    };
+    ws.onclose = () => {
+      setExec(null);
+    };
+    return () => {
+      ws.close();
+    };
+  }, [server, container]);
+
+  return { exec, isPending, isError };
+};

--- a/frontend/src/lib/socket.tsx
+++ b/frontend/src/lib/socket.tsx
@@ -69,6 +69,7 @@ export const WebsocketProvider = ({ children }: { children: ReactNode }) => {
           console.info(_count + " | Update websocket connection closed");
         },
         cancel,
+        url: url.replace("http", "wss") + "/ws/update"
       });
     }
   }, [user, cancel, connected]);

--- a/frontend/src/pages/server-info/container/index.tsx
+++ b/frontend/src/pages/server-info/container/index.tsx
@@ -31,6 +31,8 @@ import { useEditPermissions } from "@pages/resource";
 import { ResourceNotifications } from "@pages/resource-notifications";
 import { MonacoEditor } from "@components/monaco";
 import { useState } from "react";
+import { Terminal } from "xterm";
+import "xterm/css/xterm.css";
 
 export const ContainerPage = () => {
   const { type, id, container } = useParams() as {
@@ -226,6 +228,8 @@ const ContainerPageInner = ({
             />
           )}
         </Section>
+
+        <ContainerTerminal id={id} container={container_name} />
       </div>
     </div>
   );
@@ -389,4 +393,38 @@ const NewDeploymentInner = ({
       loading={isPending}
     />
   );
+};
+
+const ContainerTerminal = ({
+  id,
+  container,
+}: {
+  id: string;
+  container: string;
+}) => {
+  const terminalRef = useRef<HTMLDivElement>(null);
+  const { data: exec, isPending, isError } = useContainerExec(id, container);
+
+  useEffect(() => {
+    if (terminalRef.current && exec) {
+      const terminal = new Terminal();
+      terminal.open(terminalRef.current);
+      terminal.onData((data) => exec.send(data));
+      exec.onmessage = (event) => terminal.write(event.data);
+    }
+  }, [exec]);
+
+  if (isPending) {
+    return (
+      <div className="flex justify-center w-full py-4">
+        <Loader2 className="w-8 h-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div className="flex w-full py-4">Failed to start terminal.</div>;
+  }
+
+  return <div ref={terminalRef} className="h-96 w-full" />;
 };


### PR DESCRIPTION
Add support for in-browser container execution like xterm for Proxmox.

* **frontend/public/client/lib.js**
  - Add `executeInBrowser` function to support in-browser container execution.
  - Update `KomodoClient` function to include the `executeInBrowser` function.
  - Update WebSocket URL to use WSS for secure connection.

* **frontend/src/pages/server-info/container/index.tsx**
  - Add `ContainerTerminal` component to render an in-browser terminal for container execution.
  - Render the `ContainerTerminal` component for in-browser container execution.

* **frontend/src/lib/hooks.ts**
  - Add `useContainerExec` hook to manage in-browser container execution.

* **frontend/src/lib/socket.tsx**
  - Update WebSocket connections to support in-browser container execution.
  - Update WebSocket URL to use WSS for secure connection.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/smashyalts/komodo/pull/1?shareId=9d685708-380d-494e-a0c0-9e37a2aa07f3).